### PR TITLE
Support for components, keyup & keydown events, and modifier only shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Include it on your page somewhere after `ember.js`.
 In any route:
 
 ```javascript
-Ember.Route.Extend({
+Ember.Route.extend({
   shortcuts: {
     'shift+a': 'someAction'
   },
@@ -48,7 +48,7 @@ key up events separately.
 In any route:
 
 ```javascript
-Ember.Route.Extend({
+Ember.Route.extend({
   shortcuts: {
     'shift+a': { keyDown: 'triggeredOnKeyDown', keyUp: 'triggeredOnKeyUp' },
   },
@@ -87,7 +87,7 @@ Modify `this.shortcuts.filters` to add extra filters, for example:
 
 ```javascript
 function modalIsNotOpen() {
-  return !Ember.$('.modal)').length;
+  return !Ember.$('.modal').length;
 }
 
 function targetIsNotInput(event) {

--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ above, if a child of that route defined a `shift+a: 'otherAction'` handler and
 was active when the shortcut was pressed, the action `otherAction` would get
 sent instead of `someAction`.
 
+### KeyDown/KeyUp
+
+Passing in an object rather than a string enables listening for keydown and
+key up events separately.
+
+In any route:
+
+```
+Ember.Route.Extend({
+  shortcuts: {
+    'shift+a': { keyDown: 'triggeredOnKeyDown', keyUp: 'triggeredOnKeyUp' },
+  },
+
+  actions: {
+    triggeredOnKeyDown: function() {
+      console.log('keyDown!');
+    },
+    triggeredOnKeyUp: function() {
+      console.log('keyUp!');
+    },
+  }
+});
+```
+
 ## Injection
 
 Ember.Shortcuts, once includes, is available to you as an injected singleton on

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Include it on your page somewhere after `ember.js`.
 
 In any route:
 
-```
+```javascript
 Ember.Route.Extend({
   shortcuts: {
     'shift+a': 'someAction'
@@ -47,7 +47,7 @@ key up events separately.
 
 In any route:
 
-```
+```javascript
 Ember.Route.Extend({
   shortcuts: {
     'shift+a': { keyDown: 'triggeredOnKeyDown', keyUp: 'triggeredOnKeyUp' },
@@ -67,7 +67,7 @@ Ember.Route.Extend({
 ## Injection
 
 Ember.Shortcuts, once includes, is available to you as an injected singleton on
-your controllers and routes as the `shortcuts` property.
+your controllers, components and routes as the `shortcuts` property.
 
 **`this.shortcuts.disable`**
 **`this.shortcuts.enable`**
@@ -75,3 +75,27 @@ your controllers and routes as the `shortcuts` property.
 Call this to toggle whether or not the global keyboard shortcut handlers will
 fire.
 
+## Filters
+
+Before any event is triggered `this.shortcuts.filters` is checked to determine
+if the event will fire. 
+
+By default, ember-shortcuts checks the event target isn't an input, select or 
+text area.
+
+Modify `this.shortcuts.filters` to add extra filters, for example:
+
+```javascript
+function modalIsNotOpen() {
+  return !Ember.$('.modal)').length;
+}
+
+function targetIsNotInput(event) {
+  const tagName = event.target.tagName;
+  return (tagName !== 'INPUT') && (tagName !== 'SELECT') && (tagName !== 'TEXTAREA');
+}
+
+Ember.Shortcuts.reopen({
+  filters: [modalIsNotOpen, targetIsNotInput]
+});
+```

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-shortcuts",
   "main": "ember-shortcuts.js",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "authors": [
     "Arun Srinivasan <rulfzid@gmail.com>"
   ],

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -194,9 +194,10 @@
 
     router: Ember.computed(function() {
       var path = 'router:main';
-      return Ember.getOwner
-        ? Ember.getOwner(this).lookup(path)._routerMicrolib
-        : this.container.lookup(path)._routerMicrolib;
+      var router = Ember.getOwner
+        ? Ember.getOwner(this).lookup(path)
+        : this.container.lookup(path);
+      return router._routerMicrolib || router.router; 
     }),
 
     unbind: function() {

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -34,20 +34,20 @@
   var PRESSED_MODS = {};
   var SHORTCUTS = {};
 
-  function normalize(kc) {
-    switch (kc) {
+  function normalize(keyCode) {
+    switch (keyCode) {
       case 93: case 224: return 91; // Firefox does ⌘  weird
       case 61: return 187;          // and `=`
       case 173: return 189;         // and `-`
-      default: return kc;
+      default: return keyCode;
     }
   }
 
-  function isMod(kc) {
-    return kc === 16 || kc === 17 || kc === 18 || kc === 91;
+  function isMod(keyCode) {
+    return keyCode === 16 || keyCode === 17 || keyCode === 18 || keyCode === 91;
   }
 
-  function updatePressedMods(event, kc) {
+  function updatePressedMods(event, keyCode) {
     if (event.shiftKey) PRESSED_MODS[16] = true;
     if (event.ctrlKey)  PRESSED_MODS[17] = true;
     if (event.altKey)   PRESSED_MODS[18] = true;
@@ -67,13 +67,13 @@
     return true;
   }
 
-  function triggerEvent(filters, event, kc, callback) {
+  function triggerEvent(filters, event, keyCode, callback) {
     if (!ENABLED) return;
     if (!filter(filters, event)) return;
-    if (!(kc in SHORTCUTS)) return;
+    if (!(keyCode in SHORTCUTS)) return;
 
-    forEach(SHORTCUTS[kc], function(def) {
-      if (!isMod(kc) && !modsMatch(def)) return;
+    forEach(SHORTCUTS[keyCode], function(def) {
+      if (!isMod(keyCode) && !modsMatch(def)) return;
       Ember.run(function() { callback(def, event); });
     });
   }
@@ -104,15 +104,15 @@
     });
 
     return function dispatchKeyDownShortcut(event) {
-      var kc = normalize(event.keyCode);
+      var keyCode = normalize(event.keyCode);
 
-      PRESSED[kc] = true;
-      if (isMod(kc)) {
-        PRESSED_MODS[kc] = true;
+      PRESSED[keyCode] = true;
+      if (isMod(keyCode)) {
+        PRESSED_MODS[keyCode] = true;
       }
 
-      updatePressedMods(event, kc);
-      triggerEvent(filters, event, kc, triggerKeyDownShortcut);
+      updatePressedMods(event, keyCode);
+      triggerEvent(filters, event, keyCode, triggerKeyDownShortcut);
     };
   }
 
@@ -124,12 +124,12 @@
     });
 
     return function dispatchKeyUpShortcut(event) {
-      var kc = normalize(event.keyCode);
+      var keyCode = normalize(event.keyCode);
 
-      if (PRESSED[kc]) PRESSED[kc] = undefined;
-      if (PRESSED_MODS[kc]) PRESSED_MODS[kc] = undefined;
+      if (PRESSED[keyCode]) PRESSED[keyCode] = undefined;
+      if (PRESSED_MODS[keyCode]) PRESSED_MODS[keyCode] = undefined;
 
-      triggerEvent(filters, event, kc, triggerKeyUpShortcut);
+      triggerEvent(filters, event, keyCode, triggerKeyUpShortcut);
     };
   }
 
@@ -146,21 +146,21 @@
 
   function parse(spec) {
     var parts = spec.replace(/\s+/g, '').split('+');
-    var kc = code(parts.pop());
+    var keyCode = code(parts.pop());
     var m, mods = {};
 
     forEach(parts, function(part) {
       if (m = MODIFIERS[part]) mods[m] = true;
     });
 
-    return { mods: mods, kc: kc, raw: spec };
+    return { mods: mods, keyCode: keyCode, raw: spec };
   }
 
   function register(shortcuts) {
     forEach(shortcuts, function(spec) {
       var def = parse(spec);
-      if (!(def.kc in SHORTCUTS)) SHORTCUTS[def.kc] = [];
-      SHORTCUTS[def.kc].push(def);
+      if (!(def.keyCode in SHORTCUTS)) SHORTCUTS[def.keyCode] = [];
+      SHORTCUTS[def.keyCode].push(def);
     });
   }
 

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -215,7 +215,9 @@
   Ember.Route.reopen({
     mergedProperties: ['shortcuts'],
     registerShortcuts: function() {
-      if (this.shortcuts) register(objectKeys(this.shortcuts));
+      if (this.shortcuts && objectKeys(this.shortcuts).length) {
+        register(objectKeys(this.shortcuts));
+      }
     }.on('init')
   });
 

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -72,14 +72,14 @@
     if (!filter(filters, event)) return;
     if (!(keyCode in SHORTCUTS)) return;
 
-    forEach(SHORTCUTS[keyCode], function(def) {
-      if (!isMod(keyCode) && !modsMatch(def)) return;
-      Ember.run(function() { callback(def, event); });
+    forEach(SHORTCUTS[keyCode], function(parsedKeyBinding) {
+      if (!isMod(keyCode) && !modsMatch(parsedKeyBinding)) return;
+      Ember.run(function() { callback(parsedKeyBinding, event); });
     });
   }
 
   function makeTriggerShortcut(router, callback) {
-    return function triggerShortcut(def, event) {
+    return function triggerShortcut(parsedKeyBinding, event) {
       var actionOrObject, infos;
 
       if (!(infos = router.currentHandlerInfos)) return;
@@ -87,7 +87,7 @@
       for (var i = infos.length - 1; i >= 0; i--) {
         var handler = infos[i].handler;
 
-        if (handler.shortcuts && (actionOrObject = handler.shortcuts[def.raw])) {
+        if (handler.shortcuts && (actionOrObject = handler.shortcuts[parsedKeyBinding.raw])) {
           return callback(handler, actionOrObject);
         }
       }
@@ -138,8 +138,8 @@
     PRESSED_MODS = {};
   }
 
-  function modsMatch(def) {
-    var mods = def.mods;
+  function modsMatch(parsedKeyBinding) {
+    var mods = parsedKeyBinding.mods;
     return mods[16] === PRESSED_MODS[16] && mods[17] === PRESSED_MODS[17] &&
            mods[18] === PRESSED_MODS[18] && mods[91] === PRESSED_MODS[91];
   }
@@ -158,9 +158,9 @@
 
   function register(shortcuts) {
     forEach(shortcuts, function(spec) {
-      var def = parse(spec);
-      if (!(def.keyCode in SHORTCUTS)) SHORTCUTS[def.keyCode] = [];
-      SHORTCUTS[def.keyCode].push(def);
+      var parsedKeyBinding = parse(spec);
+      if (!(parsedKeyBinding.keyCode in SHORTCUTS)) SHORTCUTS[parsedKeyBinding.keyCode] = [];
+      SHORTCUTS[parsedKeyBinding.keyCode].push(parsedKeyBinding);
     });
   }
 

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -26,7 +26,7 @@
   for (var n = 1; n < 20; n++) DEFINITIONS['f'+n] = 111 + n;
 
   function code(c) {
-    return DEFINITIONS[c] || c.toUpperCase().charCodeAt(0);
+    return DEFINITIONS[c] || MODIFIERS[c] || c.toUpperCase().charCodeAt(0);
   }
 
   var ENABLED = true;
@@ -73,7 +73,7 @@
     if (!(kc in SHORTCUTS)) return;
 
     forEach(SHORTCUTS[kc], def => {
-      if (!modsMatch(def)) return;
+      if (!isMod(kc) && !modsMatch(def)) return;
       Ember.run(() => { callback(def, event); });
     });
   }
@@ -109,7 +109,6 @@
       PRESSED[kc] = true;
       if (isMod(kc)) {
         PRESSED_MODS[kc] = true;
-        return;
       }
 
       updatePressedMods(event, kc);

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -72,39 +72,39 @@
     if (!filter(filters, event)) return;
     if (!(kc in SHORTCUTS)) return;
 
-    forEach(SHORTCUTS[kc], def => {
+    forEach(SHORTCUTS[kc], function(def) {
       if (!isMod(kc) && !modsMatch(def)) return;
-      Ember.run(() => { callback(def, event); });
+      Ember.run(function() { callback(def, event); });
     });
   }
 
   function makeTriggerShortcut(router, callback) {
     return function triggerShortcut(def, event) {
-      let actionOrObject, handler, infos;
+      var actionOrObject, infos;
 
       if (!(infos = router.currentHandlerInfos)) return;
 
-      for (let i = infos.length - 1; i >= 0; i--) {
-        const handler = infos[i].handler;
+      for (var i = infos.length - 1; i >= 0; i--) {
+        var handler = infos[i].handler;
 
         if (handler.shortcuts && (actionOrObject = handler.shortcuts[def.raw])) {
           return callback(handler, actionOrObject);
         }
       }
-    }
+    };
   }
 
   function makeKeyDownDispatch(router, filters) {
-    const triggerKeyDownShortcut = makeTriggerShortcut(router, (handler, actionOrObject) => {
+    var triggerKeyDownShortcut = makeTriggerShortcut(router, function(handler, actionOrObject) {
       if (typeof actionOrObject === 'string') {
         handler.send(actionOrObject, event);
       } else {
         handler.send(actionOrObject.keyDown, event);
       }
-    })
+    });
 
     return function dispatchKeyDownShortcut(event) {
-      const kc = normalize(event.keyCode);
+      var kc = normalize(event.keyCode);
 
       PRESSED[kc] = true;
       if (isMod(kc)) {
@@ -117,14 +117,14 @@
   }
 
   function makeKeyUpDispatch(router, filters) {
-    const triggerKeyUpShortcut = makeTriggerShortcut(router, (handler, actionOrObject) => {
+    var triggerKeyUpShortcut = makeTriggerShortcut(router, function(handler, actionOrObject) {
       if (typeof actionOrObject === 'object') {
         handler.send(actionOrObject.keyUp, event);
       }
-    })
+    });
 
     return function dispatchKeyUpShortcut(event) {
-      const kc = normalize(event.keyCode);
+      var kc = normalize(event.keyCode);
 
       if (PRESSED[kc]) PRESSED[kc] = undefined;
       if (PRESSED_MODS[kc]) PRESSED_MODS[kc] = undefined;
@@ -150,7 +150,7 @@
     var m, mods = {};
 
     forEach(parts, function(part) {
-      if ((m = MODIFIERS[part])) mods[m] = true;
+      if (m = MODIFIERS[part]) mods[m] = true;
     });
 
     return { mods: mods, kc: kc, raw: spec };
@@ -180,11 +180,11 @@
     filters: [targetIsNotInput],
 
     init: function() {
-      const router = this.get('router');
-      const filters = this.get('filters');
+      var router = this.get('router');
+      var filters = this.get('filters');
 
-      const keyDownDispatch = makeKeyDownDispatch(router, filters);
-      const keyUpDispatch = makeKeyUpDispatch(router, filters);
+      var keyDownDispatch = makeKeyDownDispatch(router, filters);
+      var keyUpDispatch = makeKeyUpDispatch(router, filters);
 
       $doc.on('keydown.ember-shortcuts', keyDownDispatch);
       $doc.on('keyup.ember-shortcuts', keyUpDispatch);
@@ -232,4 +232,4 @@
       }
     });
   });
-}(Ember, Ember.$));
+})(Ember, Ember.$);

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -54,17 +54,10 @@
     if (event.metaKey)  PRESSED_MODS[91] = true;
   }
 
-  function forEach(array, fn) {
-    for (var i = 0, len = array.length; i < len; i++) {
-      fn(array[i]);
-    }
-  }
-
   function filter(filters, event) {
-    for (var i = 0; i < filters.length; i++) {
-      if (!filters[i](event)) return false;
-    }
-    return true;
+    return !filters.any(function(filter) {
+      return !filter(event);
+    });
   }
 
   function triggerEvent(filters, event, keyCode, callback) {
@@ -72,7 +65,7 @@
     if (!filter(filters, event)) return;
     if (!(keyCode in SHORTCUTS)) return;
 
-    forEach(SHORTCUTS[keyCode], function(parsedKeyBinding) {
+    SHORTCUTS[keyCode].forEach(function(parsedKeyBinding) {
       if (!isMod(keyCode) && !modsMatch(parsedKeyBinding)) return;
       Ember.run(function() { callback(parsedKeyBinding, event); });
     });
@@ -149,7 +142,7 @@
     var keyCode = code(parts.pop());
     var m, mods = {};
 
-    forEach(parts, function(part) {
+    parts.forEach(function(part) {
       if (m = MODIFIERS[part]) mods[m] = true;
     });
 
@@ -157,7 +150,7 @@
   }
 
   function register(shortcuts) {
-    forEach(shortcuts, function(spec) {
+    shortcuts.forEach(function(spec) {
       var parsedKeyBinding = parse(spec);
       if (!(parsedKeyBinding.keyCode in SHORTCUTS)) SHORTCUTS[parsedKeyBinding.keyCode] = [];
       SHORTCUTS[parsedKeyBinding.keyCode].push(parsedKeyBinding);


### PR DESCRIPTION
This adds support for ember components, listening for keyup events and modifier only shortcuts.

The target is our fork of @satchmorun's library (https://github.com/satchmorun/ember-shortcuts). As per the update to readme.md:

> Passing in an object rather than a string enables listening for keydown and
key up events separately.
> For example:

```javascript
Ember.Route.Extend({
  shortcuts: {
    'shift+a': { keyDown: 'triggeredOnKeyDown', keyUp: 'triggeredOnKeyUp' },
  },

  actions: {
    triggeredOnKeyDown: function() {
      console.log('keyDown!');
    },
    triggeredOnKeyUp: function() {
      console.log('keyUp!');
    },
  }
});
```

It would be nice to publish these changes, either under `harvesthq` or to `satchmorun`, but let's not let that discussion hold up this PR.

