### PR TITLE
Pass event to the callback sent to ember

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+bower_components

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-shortcuts",
   "main": "ember-shortcuts.js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "authors": [
     "Arun Srinivasan <rulfzid@gmail.com>"
   ],

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -81,14 +81,14 @@
         var handler = infos[i].handler;
 
         if (handler.shortcuts && (actionOrObject = handler.shortcuts[parsedKeyBinding.raw])) {
-          return callback(handler, actionOrObject);
+          return callback(handler, actionOrObject, event);
         }
       }
     };
   }
 
   function makeKeyDownDispatch(router, filters) {
-    var triggerKeyDownShortcut = makeTriggerShortcut(router, function(handler, actionOrObject) {
+    var triggerKeyDownShortcut = makeTriggerShortcut(router, function(handler, actionOrObject, event) {
       if (typeof actionOrObject === 'string') {
         handler.send(actionOrObject, event);
       } else {
@@ -110,7 +110,7 @@
   }
 
   function makeKeyUpDispatch(router, filters) {
-    var triggerKeyUpShortcut = makeTriggerShortcut(router, function(handler, actionOrObject) {
+    var triggerKeyUpShortcut = makeTriggerShortcut(router, function(handler, actionOrObject, event) {
       if (typeof actionOrObject === 'object') {
         handler.send(actionOrObject.keyUp, event);
       }


### PR DESCRIPTION
Looks like https://github.com/harvesthq/ember-shortcuts/pull/1 didn't correctly pass on the event to the handler. Chrome / Safari / IE seem to swallow this error, but it was causing Firefox to trip up.